### PR TITLE
Fix handling of ties

### DIFF
--- a/app/engine/engine.test.ts
+++ b/app/engine/engine.test.ts
@@ -6,6 +6,7 @@ import {
   CANT_BUZZ_FLAG,
   CLUE_TIMEOUT_MS,
   gameEngine,
+  getWinningBuzzer,
 } from "./engine";
 import type { Player } from "./state";
 import { GameState, State } from "./state";
@@ -1934,4 +1935,19 @@ describe("gameEngine", () => {
       expect(state).toStrictEqual(tc.expectedState);
     });
   }
+});
+
+describe("getWinningBuzzer", () => {
+  it("returns the buzz of the lower user ID in case of a tie", () => {
+    // NB: Maps iterate over keys in insertion order
+    let buzzes = new Map();
+    buzzes.set(PLAYER1.userId, 100);
+    buzzes.set(PLAYER2.userId, 100);
+    expect(getWinningBuzzer(buzzes)?.userId).toBe(PLAYER1.userId);
+
+    buzzes = new Map();
+    buzzes.set(PLAYER2.userId, 100);
+    buzzes.set(PLAYER1.userId, 100);
+    expect(getWinningBuzzer(buzzes)?.userId).toBe(PLAYER1.userId);
+  });
 });

--- a/app/engine/engine.ts
+++ b/app/engine/engine.ts
@@ -47,19 +47,22 @@ export function getWinningBuzzer(buzzes: Map<string, number>):
       deltaMs: number;
     }
   | undefined {
-  const result = Array.from(buzzes.entries()).reduce(
-    (acc, [userId, deltaMs]) => {
-      if (
-        deltaMs !== CANT_BUZZ_FLAG &&
-        deltaMs < acc.deltaMs &&
-        deltaMs <= CLUE_TIMEOUT_MS
-      ) {
-        return { userId, deltaMs };
-      }
-      return acc;
-    },
-    { userId: "", deltaMs: Number.MAX_SAFE_INTEGER },
-  );
+  const result = Array.from(buzzes.entries())
+    // Sort buzzes by user ID for deterministic results in case of a tie.
+    .sort(([aUserId], [bUserId]) => (aUserId > bUserId ? 1 : -1))
+    .reduce(
+      (acc, [userId, deltaMs]) => {
+        if (
+          deltaMs !== CANT_BUZZ_FLAG &&
+          deltaMs < acc.deltaMs &&
+          deltaMs <= CLUE_TIMEOUT_MS
+        ) {
+          return { userId, deltaMs };
+        }
+        return acc;
+      },
+      { userId: "", deltaMs: Number.MAX_SAFE_INTEGER },
+    );
 
   if (result.userId === "") {
     return undefined;


### PR DESCRIPTION
Currently, when two players exactly tie (in milliseconds) on a buzz, their clients can end up in a state where each client believes it has won the buzz.

In the `getWinningBuzzer` function, we iterate through the `buzzes` map to find a winner. Since [JavaScript `Map`'s iterate in insertion order](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#:~:text=a%20Symbol.-,Key%20Order,-The%20keys%20in), this can create a local client-dependent ordering on `buzzes`. In the case of a tie, when we reduce to find the minimum `delayMs` time, this order will decided the winner.

The fix in this PR orders the iteration through the entries of `buzzes` by `userId` prior to searching for a minimum delay. This ensures that the user with a lower `userId` wins ties, making all clients determine the same winner each time. 

This slightly suboptimal; we'd prefer that each tie get resolved randomly (so that no one player has an advantage). However, ties are rare in the first place, and I'd suggest a more robust solution is to use [`performance.now()` instead of `Date.now()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#performance.now_vs._date.now), which would yield sub-millisecond accuracy that would make ties very unlikely. I'll leave that fix for a later PR.