### PR TITLE
Migrations to add indexes and realtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ Start the Supabase project:
 npx supabase start
 ```
 
-> **Warning**
->
-> Enable Realtime events manually on the `room_events` table for multiplayer
-> games to work:
->
-> **http://localhost:54323/project/default/database/tables**
-
 Set environment variables. In particular, set `SUPABASE_URL`,
 `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` from the results of `npx
 supabase status`.

--- a/supabase/migrations/20231222053755_realtime_room_events.sql
+++ b/supabase/migrations/20231222053755_realtime_room_events.sql
@@ -1,0 +1,2 @@
+alter
+  publication supabase_realtime add table room_events;

--- a/supabase/migrations/20231222193525_index_foreign_keys.sql
+++ b/supabase/migrations/20231222193525_index_foreign_keys.sql
@@ -1,0 +1,12 @@
+-- Index all foreign keys, on all tables
+
+create index "categories_game_id_fkey_idx" on "public"."categories" (game_id);
+create index "clues_category_id_fkey_idx" on "public"."clues" (category_id);
+create index "games_uploaded_by_fkey_idx" on "public"."games" (uploaded_by);
+create index "reports_created_by_fkey_idx" on "public"."reports" (created_by);
+create index "reports_game_id_fkey_idx" on "public"."reports" (game_id);
+create index "room_events_room_id_fkey_idx" on "public"."room_events" (room_id);
+create index "rooms_game_id_fkey_idx" on "public"."rooms" (game_id);
+create index "solves_game_id_fkey_idx" on "public"."solves" (game_id);
+create index "solves_room_id_fkey_idx" on "public"."solves" (room_id);
+create index "solves_user_id_fkey_idx" on "public"."solves" (user_id);


### PR DESCRIPTION
Postgres doesn't automatically index foreign keys, so we add them manually. This speeds up child-to-parent queries significantly, which may help mitigate timeout issues.

I have tested the migrations locally, and confirmed they increase use of indexes (from ~50% on the `games` table to ~90%). You can compute statistics about index usage on a local database with `npx supabase inspect db index-usage --db-url postgresql://postgres:postgres@localhost:54322/postgres`.
