### PR TITLE
Improve buzzer: fair tiebreaks and quantization

### DIFF
--- a/app/components/prompt/prompt.tsx
+++ b/app/components/prompt/prompt.tsx
@@ -9,6 +9,7 @@ import type { Action, Player } from "~/engine";
 import {
   CANT_BUZZ_FLAG,
   CLUE_TIMEOUT_MS,
+  QUANTIZATION_FACTOR_MS,
   GameState,
   useEngineContext,
 } from "~/engine";
@@ -402,7 +403,7 @@ function ReadCluePrompt({
         if (
           buzzUserId !== userId &&
           buzz !== CANT_BUZZ_FLAG &&
-          buzz < deltaMs
+          (buzz + QUANTIZATION_FACTOR_MS) < deltaMs
         ) {
           submitBuzz(CLUE_TIMEOUT_MS + 1);
         }

--- a/app/engine/engine.test.ts
+++ b/app/engine/engine.test.ts
@@ -2208,16 +2208,22 @@ describe("gameEngine", () => {
 });
 
 describe("getWinningBuzzer", () => {
-  it("returns the buzz of the lower user ID in case of a tie", () => {
-    // NB: Maps iterate over keys in insertion order
-    let buzzes = new Map();
-    buzzes.set(PLAYER1.userId, 100);
-    buzzes.set(PLAYER2.userId, 100);
-    expect(getWinningBuzzer(buzzes)?.userId).toBe(PLAYER1.userId);
-
-    buzzes = new Map();
-    buzzes.set(PLAYER2.userId, 100);
-    buzzes.set(PLAYER1.userId, 100);
-    expect(getWinningBuzzer(buzzes)?.userId).toBe(PLAYER1.userId);
+  it("measures the buzzer winrate between two equally fast players over 1000 trials. Expected to be near 50-50", () => {
+    let player1Wins = 0;
+    const n_trials = 1000;
+    for (let trial = 0; trial < n_trials; trial++) {
+      const tiebreakSeed = Math.random().toString() + trial.toString();
+      const buzzes = new Map();
+      buzzes.set(PLAYER1.userId, 100);
+      buzzes.set(PLAYER2.userId, 100);
+      const winner = getWinningBuzzer(buzzes, tiebreakSeed)?.userId;
+      if (winner === PLAYER1.userId) {
+        player1Wins++;
+      }
+    }
+    // CDF of bin(n=1000, p=0.5) = 0.99999 @ k = 435
+    const k = 435;
+    expect(player1Wins).toBeGreaterThan(k);
+    expect(player1Wins).toBeLessThan(n_trials - k);
   });
 });

--- a/app/engine/index.ts
+++ b/app/engine/index.ts
@@ -2,11 +2,12 @@ export {
   ActionType,
   CANT_BUZZ_FLAG,
   CLUE_TIMEOUT_MS,
+  QUANTIZATION_FACTOR_MS,
   gameEngine,
   getHighestClueValue,
 } from "./engine";
 export type { Action } from "./engine";
-export { clueIsPlayable, GameState } from "./state";
+export { GameState, clueIsPlayable } from "./state";
 export type { Player, State } from "./state";
 export { GameEngineContext, useEngineContext } from "./use-engine-context";
 export { useGameEngine, useSoloGameEngine } from "./use-game-engine";

--- a/app/engine/use-game-engine.ts
+++ b/app/engine/use-game-engine.ts
@@ -8,7 +8,7 @@ import { getSupabase } from "~/supabase";
 import type { Action } from "./engine";
 import { gameEngine, getWinningBuzzer } from "./engine";
 import { applyRoomEventsToState, isTypedRoomEvent } from "./room-event";
-import { getClueValue, State, stateFromGame } from "./state";
+import { State, getClueValue, stateFromGame } from "./state";
 
 export enum ConnectionState {
   ERROR,
@@ -55,7 +55,7 @@ function stateToGameEngine(
       ?.answeredBy.get(userId);
   };
 
-  const winningBuzz = getWinningBuzzer(state.buzzes);
+  const winningBuzz = getWinningBuzzer(state.buzzes, clue?.clue);
   const winningBuzzer = winningBuzz?.userId ?? undefined;
 
   function getClueValueFn(idx: [number, number], userId: string) {

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -3,6 +3,7 @@ export * from "./http.server";
 export * from "./is-browser";
 export { getRandomEmoji, getRandomName } from "./name";
 export {
+  cyrb53,
   formatDollars,
   formatDollarsWithSign,
   generateGrid,

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -42,7 +42,7 @@ export function formatDollarsWithSign(dollars: number) {
   return signFormatter.format(dollars);
 }
 
-const cyrb53 = (str: string, seed = 0) => {
+export const cyrb53 = (str: string, seed = 0) => {
   let h1 = 0xdeadbeef ^ seed,
     h2 = 0x41c6ce57 ^ seed;
   for (let i = 0, ch; i < str.length; i++) {


### PR DESCRIPTION
Buzzer ties are now broken randomly, independently for each clue.
Buzzer times are rounded to the nearest 100ms to slightly deweight buzzer racing as a game mechanic.