### PR TITLE
ci: run E2E tests against local Supabase

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,14 @@ jobs:
         # db:start only starts the kong and postgrest containers.
         run: npm run db:start
 
+      - name: Export local Supabase env vars
+        run: |
+          npx supabase status -o env \
+            --override-name api.url=SUPABASE_URL \
+            --override-name auth.anon_key=SUPABASE_ANON_KEY \
+            --override-name auth.service_role_key=SUPABASE_SERVICE_ROLE_KEY \
+            | grep -E '^SUPABASE_(URL|ANON_KEY|SERVICE_ROLE_KEY)=' >> .env
+
       - name: 🌐 Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
@@ -81,9 +89,6 @@ jobs:
           CI: "true"
           PORT: "8811"
           BASE_URL: "http://localhost:8811"
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
 
       - name: 📤 Upload Playwright report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The Playwright workflow starts a local Supabase stack, but then passes SUPABASE_* values from GitHub secrets into the test step. If those secrets point at production, E2E tests can create production data, including the guest public upload test fixture.

Export the local Supabase credentials from supabase status -o env into .env, and stop passing remote Supabase secrets to Playwright.

This preserves the existing upload coverage while keeping all E2E database writes in the CI-local Supabase instance.