### PR TITLE
fix: persist category notes when uploading games

### DIFF
--- a/app/models/game.server.ts
+++ b/app/models/game.server.ts
@@ -236,6 +236,7 @@ export async function createGame(
       categoriesToInsert.push({
         game_id: game.id,
         name: category.name,
+        note: category.note ?? null,
         round,
       });
     }


### PR DESCRIPTION
Category notes are documented in the upload schema and the board UI already renders them as Note: ..., but createGame() dropped category.note when inserting rows into categories.

Persist category.note into the existing nullable categories.note column so uploaded category notes show up during gameplay.