### PR TITLE
feat: undo button for corrections (#40)

### DIFF
--- a/app/components/check-correction-button.tsx
+++ b/app/components/check-correction-button.tsx
@@ -1,0 +1,46 @@
+import { useFetcher } from "react-router";
+
+import Button from "~/components/button";
+import type { RoomProps } from "~/components/game";
+import type { Action } from "~/engine";
+import { useEngineContext } from "~/engine";
+import { formatDollarsWithSign } from "~/utils";
+import useSoloAction from "~/utils/use-solo-action";
+
+export default function CheckCorrectionButton({ roomId, userId }: RoomProps) {
+  const { getCheckCorrection, soloDispatch } = useEngineContext();
+  const correction = getCheckCorrection(userId);
+  const fetcher = useFetcher<Action>();
+  useSoloAction(fetcher, soloDispatch);
+
+  if (!correction) {
+    return null;
+  }
+
+  const nextCorrect = !correction.correct;
+  const scoreSwing = correction.value * 2 * (nextCorrect ? 1 : -1);
+  const result = nextCorrect ? "correct" : "incorrect";
+
+  return (
+    <fetcher.Form
+      method="POST"
+      action={`/room/${roomId}/correct-check`}
+      className="ml-auto"
+    >
+      <input type="hidden" name="round" value={correction.round} />
+      <input type="hidden" name="i" value={correction.i} />
+      <input type="hidden" name="j" value={correction.j} />
+      <input type="hidden" name="userId" value={userId} />
+      <Button
+        type="transparent"
+        htmlType="submit"
+        name="result"
+        value={result}
+        loading={fetcher.state === "loading"}
+        className="whitespace-nowrap"
+      >
+        Mark previous answer {result} ({formatDollarsWithSign(scoreSwing)})
+      </Button>
+    </fetcher.Form>
+  );
+}

--- a/app/components/check-correction-button.tsx
+++ b/app/components/check-correction-button.tsx
@@ -25,7 +25,6 @@ export default function CheckCorrectionButton({ roomId, userId }: RoomProps) {
     <fetcher.Form
       method="POST"
       action={`/room/${roomId}/correct-check`}
-      className="ml-auto"
     >
       <input type="hidden" name="round" value={correction.round} />
       <input type="hidden" name="i" value={correction.i} />

--- a/app/components/check-correction-button.tsx
+++ b/app/components/check-correction-button.tsx
@@ -22,10 +22,7 @@ export default function CheckCorrectionButton({ roomId, userId }: RoomProps) {
   const result = nextCorrect ? "correct" : "incorrect";
 
   return (
-    <fetcher.Form
-      method="POST"
-      action={`/room/${roomId}/correct-check`}
-    >
+    <fetcher.Form method="POST" action={`/room/${roomId}/correct-check`}>
       <input type="hidden" name="round" value={correction.round} />
       <input type="hidden" name="i" value={correction.i} />
       <input type="hidden" name="j" value={correction.j} />

--- a/app/components/game.tsx
+++ b/app/components/game.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useNavigate } from "react-router";
 
 import BoardComponent from "~/components/board";
+import CheckCorrectionButton from "~/components/check-correction-button";
 import Connection from "~/components/connection";
 import GameClock from "~/components/game-clock";
 import Link from "~/components/link";
@@ -124,7 +125,7 @@ export default function GameComponent({
         <div
           className={`mx-auto flex w-full max-w-screen-lg flex-col gap-4 p-3 text-slate-100 sm:p-6 md:p-12`}
         >
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-2">
             <CallToAction
               boardController={boardController}
               type={type}
@@ -132,6 +133,7 @@ export default function GameComponent({
               roomName={roomName}
               userId={userId}
             />
+            <CheckCorrectionButton roomId={roomId} userId={userId} />
             <GameClock roomId={roomId} />
           </div>
           <PlayerScores roomId={roomId} userId={userId} />

--- a/app/components/game.tsx
+++ b/app/components/game.tsx
@@ -125,16 +125,24 @@ export default function GameComponent({
         <div
           className={`mx-auto flex w-full max-w-screen-lg flex-col gap-4 p-3 text-slate-100 sm:p-6 md:p-12`}
         >
-          <div className="flex items-center justify-between gap-2">
-            <CallToAction
-              boardController={boardController}
-              type={type}
-              isSingleLongFormClue={isSingleLongFormClue}
-              roomName={roomName}
-              userId={userId}
-            />
-            <CheckCorrectionButton roomId={roomId} userId={userId} />
-            <GameClock roomId={roomId} />
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="order-1">
+              <CallToAction
+                boardController={boardController}
+                type={type}
+                isSingleLongFormClue={isSingleLongFormClue}
+                roomName={roomName}
+                userId={userId}
+              />
+            </div>
+
+            <div className="order-3 ml-auto sm:order-2">
+              <CheckCorrectionButton roomId={roomId} userId={userId} />
+            </div>
+
+            <div className="order-2 sm:order-3">
+              <GameClock roomId={roomId} />
+            </div>
           </div>
           <PlayerScores roomId={roomId} userId={userId} />
           <Connection

--- a/app/engine/actions.ts
+++ b/app/engine/actions.ts
@@ -31,6 +31,7 @@ const RoundPayload = z.object({ round: z.number(), userId: z.string() });
 const BuzzPayload = CluePayload.extend({ deltaMs: z.number() });
 const AnswerPayload = CluePayload.extend({ answer: z.string() });
 const CheckPayload = CluePayload.extend({ correct: z.boolean() });
+const CorrectCheckPayload = CheckPayload.extend({ round: z.number() });
 const TransferPlayerPayload = z.object({
   oldUserId: z.string(),
   newUserId: z.string(),
@@ -128,6 +129,23 @@ export function isCheckAction(action: Action): action is {
   return (
     action.type === ActionType.Check &&
     CheckPayload.safeParse(action.payload).success
+  );
+}
+
+export function isCorrectCheckAction(action: Action): action is {
+  type: ActionType.CorrectCheck;
+  payload: {
+    round: number;
+    userId: string;
+    i: number;
+    j: number;
+    correct: boolean;
+  };
+  ts: number;
+} {
+  return (
+    action.type === ActionType.CorrectCheck &&
+    CorrectCheckPayload.safeParse(action.payload).success
   );
 }
 

--- a/app/engine/engine.test.ts
+++ b/app/engine/engine.test.ts
@@ -12,7 +12,12 @@ import {
   parseUtcMs,
 } from "./engine";
 import type { Player } from "./state";
-import { GameState, State, stateFromGame } from "./state";
+import {
+  GameState,
+  State,
+  getCheckCorrectionForPlayer,
+  stateFromGame,
+} from "./state";
 
 /** TestAction allows omitting ts; the test runner defaults it to 0. */
 type TestAction = Omit<Action, "ts"> & { ts?: number };
@@ -2832,6 +2837,295 @@ describe("gameEngine", () => {
       );
     });
   }
+
+  it("corrects a right buzzed answer to wrong after returning to the board", () => {
+    const actions: TestAction[] = [
+      ...TWO_PLAYERS_ROUND_0,
+      {
+        type: ActionType.ChooseClue,
+        payload: { userId: PLAYER1.userId, i: 0, j: 0 },
+      },
+      {
+        type: ActionType.Buzz,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0, deltaMs: 123 },
+      },
+      {
+        type: ActionType.Buzz,
+        payload: {
+          userId: PLAYER1.userId,
+          i: 0,
+          j: 0,
+          deltaMs: CLUE_TIMEOUT_MS + 1,
+        },
+      },
+      {
+        type: ActionType.Check,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0, correct: true },
+      },
+      {
+        type: ActionType.NextClue,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0 },
+      },
+      {
+        type: ActionType.CorrectCheck,
+        payload: {
+          round: 0,
+          userId: PLAYER2.userId,
+          i: 0,
+          j: 0,
+          correct: false,
+        },
+      },
+    ];
+
+    let state = initialState;
+    for (const action of actions) {
+      state = gameEngine(state, { ts: 0, ...action });
+    }
+
+    expect(state.type).toBe(GameState.ShowBoard);
+    expect(state.boardControl).toBe(PLAYER1.userId);
+    expect(state.players.get(PLAYER2.userId)?.score).toBe(-200);
+    expect(state.isAnswered[0][0][0].answeredBy).toStrictEqual(
+      new Map([[PLAYER2.userId, false]]),
+    );
+    expect(getCheckCorrectionForPlayer(state, PLAYER2.userId)?.correct).toBe(
+      false,
+    );
+  });
+
+  it("restores board control to an active player if the prior controller leaves", () => {
+    const actions: TestAction[] = [
+      ...TWO_PLAYERS_ROUND_0,
+      {
+        type: ActionType.ChooseClue,
+        payload: { userId: PLAYER1.userId, i: 0, j: 0 },
+      },
+      {
+        type: ActionType.Buzz,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0, deltaMs: 123 },
+      },
+      {
+        type: ActionType.Buzz,
+        payload: {
+          userId: PLAYER1.userId,
+          i: 0,
+          j: 0,
+          deltaMs: CLUE_TIMEOUT_MS + 1,
+        },
+      },
+      {
+        type: ActionType.Check,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0, correct: true },
+      },
+      {
+        type: ActionType.NextClue,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0 },
+      },
+      { type: ActionType.Leave, payload: PLAYER1 },
+      {
+        type: ActionType.CorrectCheck,
+        payload: {
+          round: 0,
+          userId: PLAYER2.userId,
+          i: 0,
+          j: 0,
+          correct: false,
+        },
+      },
+    ];
+
+    let state = initialState;
+    for (const action of actions) {
+      state = gameEngine(state, { ts: 0, ...action });
+    }
+
+    expect(state.type).toBe(GameState.ShowBoard);
+    expect(state.boardControl).toBe(PLAYER2.userId);
+    expect(state.players.has(PLAYER1.userId)).toBe(false);
+    expect(state.leftPlayers.has(PLAYER1.userId)).toBe(true);
+    expect(state.players.get(PLAYER2.userId)?.score).toBe(-200);
+  });
+
+  it("restores later answers when undoing a correction", () => {
+    const actions: TestAction[] = [
+      ...TWO_PLAYERS_ROUND_0,
+      {
+        type: ActionType.ChooseClue,
+        payload: { userId: PLAYER1.userId, i: 0, j: 0 },
+      },
+      {
+        type: ActionType.Buzz,
+        payload: { userId: PLAYER1.userId, i: 0, j: 0, deltaMs: 123 },
+      },
+      {
+        type: ActionType.Buzz,
+        payload: {
+          userId: PLAYER2.userId,
+          i: 0,
+          j: 0,
+          deltaMs: CLUE_TIMEOUT_MS + 1,
+        },
+      },
+      {
+        type: ActionType.Check,
+        payload: { userId: PLAYER1.userId, i: 0, j: 0, correct: false },
+      },
+      {
+        type: ActionType.Buzz,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0, deltaMs: 123 },
+      },
+      {
+        type: ActionType.Check,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0, correct: true },
+      },
+      {
+        type: ActionType.NextClue,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0 },
+      },
+      {
+        type: ActionType.CorrectCheck,
+        payload: {
+          round: 0,
+          userId: PLAYER1.userId,
+          i: 0,
+          j: 0,
+          correct: true,
+        },
+      },
+    ];
+
+    let state = initialState;
+    for (const action of actions) {
+      state = gameEngine(state, { ts: 0, ...action });
+    }
+
+    expect(state.boardControl).toBe(PLAYER1.userId);
+    expect(state.players.get(PLAYER1.userId)?.score).toBe(200);
+    expect(state.players.get(PLAYER2.userId)?.score).toBe(0);
+    expect(state.isAnswered[0][0][0].answeredBy).toStrictEqual(
+      new Map([[PLAYER1.userId, true]]),
+    );
+    expect(getCheckCorrectionForPlayer(state, PLAYER2.userId)).toBeUndefined();
+
+    state = gameEngine(state, {
+      type: ActionType.CorrectCheck,
+      payload: {
+        round: 0,
+        userId: PLAYER1.userId,
+        i: 0,
+        j: 0,
+        correct: false,
+      },
+      ts: 0,
+    });
+
+    expect(state.boardControl).toBe(PLAYER2.userId);
+    expect(state.players.get(PLAYER1.userId)?.score).toBe(-200);
+    expect(state.players.get(PLAYER2.userId)?.score).toBe(200);
+    expect(state.isAnswered[0][0][0].answeredBy).toStrictEqual(
+      new Map([
+        [PLAYER1.userId, false],
+        [PLAYER2.userId, true],
+      ]),
+    );
+    expect(getCheckCorrectionForPlayer(state, PLAYER2.userId)?.correct).toBe(
+      true,
+    );
+  });
+
+  it("corrects wagered answers using a double-value score swing", () => {
+    const actions: TestAction[] = [
+      ...TWO_PLAYERS_ROUND_1,
+      {
+        type: ActionType.StartRound,
+        payload: { round: 1, userId: PLAYER2.userId },
+      },
+      {
+        type: ActionType.ChooseClue,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0 },
+      },
+      {
+        type: ActionType.SetClueWager,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0, wager: 345 },
+      },
+      {
+        type: ActionType.Buzz,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0, deltaMs: 123 },
+      },
+      {
+        type: ActionType.Check,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0, correct: true },
+      },
+      {
+        type: ActionType.NextClue,
+        payload: { userId: PLAYER2.userId, i: 0, j: 0 },
+      },
+      {
+        type: ActionType.CorrectCheck,
+        payload: {
+          round: 1,
+          userId: PLAYER2.userId,
+          i: 0,
+          j: 0,
+          correct: false,
+        },
+      },
+    ];
+
+    let state = initialState;
+    for (const action of actions) {
+      state = gameEngine(state, { ts: 0, ...action });
+    }
+
+    expect(state.type).toBe(GameState.ShowBoard);
+    expect(state.players.get(PLAYER2.userId)?.score).toBe(-345);
+    expect(getCheckCorrectionForPlayer(state, PLAYER2.userId)).toMatchObject({
+      correct: false,
+      value: 345,
+    });
+  });
+
+  it("corrects the last answer from the previous round on the next board", () => {
+    const actions: TestAction[] = [
+      ...TWO_PLAYERS_ROUND_1,
+      {
+        type: ActionType.StartRound,
+        payload: { round: 1, userId: PLAYER2.userId },
+      },
+      {
+        type: ActionType.CorrectCheck,
+        payload: {
+          round: 0,
+          userId: PLAYER1.userId,
+          i: 0,
+          j: 1,
+          correct: false,
+        },
+      },
+    ];
+
+    let state = initialState;
+    for (const action of actions) {
+      state = gameEngine(state, { ts: 0, ...action });
+    }
+
+    expect(state.type).toBe(GameState.ShowBoard);
+    expect(state.round).toBe(1);
+    expect(state.boardControl).toBe(PLAYER1.userId);
+    expect(state.players.get(PLAYER1.userId)?.score).toBe(0);
+    expect(state.players.get(PLAYER2.userId)?.score).toBe(0);
+    expect(state.isAnswered[0][0][1].answeredBy).toStrictEqual(
+      new Map([[PLAYER1.userId, false]]),
+    );
+    expect(getCheckCorrectionForPlayer(state, PLAYER1.userId)).toMatchObject({
+      round: 0,
+      i: 0,
+      j: 1,
+      correct: false,
+      value: 200,
+    });
+  });
 
   it("TransferPlayer is no-op after GameOver", () => {
     // Build a GameOver state directly rather than replaying the full game.

--- a/app/engine/engine.ts
+++ b/app/engine/engine.ts
@@ -9,6 +9,7 @@ import {
   isBuzzAction,
   isCheckAction,
   isClueAction,
+  isCorrectCheckAction,
   isClueWagerAction,
   isPlayerAction,
   isRoundAction,
@@ -16,10 +17,13 @@ import {
   isTransferPlayerAction,
 } from "./actions";
 import {
+  type CheckCorrection,
   type ClueAnswer,
   GameState,
   State,
   getClueValue,
+  getClueValueForRound,
+  getCountedChecks,
   getNumCluesInBoard,
 } from "./state";
 
@@ -71,6 +75,7 @@ export enum ActionType {
    * points.
    */
   Check = "check",
+  CorrectCheck = "correct_check",
   NextClue = "next_clue",
   ToggleClock = "toggle_clock",
   TransferPlayer = "transfer_player",
@@ -171,15 +176,32 @@ export function getHighestClueValue(board: Board | undefined) {
   return max;
 }
 
-/** Transfer board control away from userId to the next player. */
-function transferBoardControl(draft: Draft<State>, userId: string) {
-  if (draft.boardControl !== userId) return;
+function getNextBoardControl(draft: Draft<State>, userId: string) {
   const otherIds = Array.from(draft.players.keys()).filter(
     (id) => id !== userId,
   );
   otherIds.sort();
-  if (otherIds.length > 0) {
-    draft.boardControl = otherIds[0];
+  return otherIds[0];
+}
+
+/** Transfer board control away from userId to the next player. */
+function transferBoardControl(draft: Draft<State>, userId: string) {
+  if (draft.boardControl !== userId) return;
+  const nextBoardControl = getNextBoardControl(draft, userId);
+  if (nextBoardControl) {
+    draft.boardControl = nextBoardControl;
+  }
+}
+
+function transferCheckCorrectionBoardControl(
+  draft: Draft<State>,
+  userId: string,
+) {
+  const correction = draft.checkCorrection;
+  if (correction?.boardControlBefore !== userId) return;
+  const nextBoardControl = getNextBoardControl(draft, userId);
+  if (nextBoardControl) {
+    correction.boardControlBefore = nextBoardControl;
   }
 }
 
@@ -206,6 +228,139 @@ function pauseClock(draft: Draft<State>, ts: number) {
   draft.clockAccumulatedMs += Math.max(0, elapsed);
   draft.clockRunning = false;
   draft.clockLastResumedAt = null;
+}
+
+function getCheckScoreDelta(correct: boolean | undefined, value: number) {
+  if (correct === undefined) {
+    return 0;
+  }
+  return correct ? value : -value;
+}
+
+function recordCheckCorrection(
+  draft: Draft<State>,
+  i: number,
+  j: number,
+  userId: string,
+  correct: boolean,
+) {
+  const correction = draft.checkCorrection;
+  if (
+    correction &&
+    correction.round === draft.round &&
+    correction.i === i &&
+    correction.j === j
+  ) {
+    correction.checks.set(userId, correct);
+    return;
+  }
+
+  draft.checkCorrection = {
+    round: draft.round,
+    i,
+    j,
+    boardControlBefore: draft.boardControl,
+    checks: new Map([[userId, correct]]),
+  };
+}
+
+function getCorrectBoardControl(
+  checks: Map<string, boolean>,
+  boardControlBefore: string | null,
+) {
+  for (const [userId, correct] of checks) {
+    if (correct) {
+      return userId;
+    }
+  }
+  return boardControlBefore;
+}
+
+function getHighestScoringPlayerId(draft: Draft<State>) {
+  return Array.from(draft.players.entries()).sort(
+    ([, a], [, b]) => b.score - a.score,
+  )[0]?.[0];
+}
+
+function getNextRoundBoardControl(
+  draft: Draft<State>,
+  fallbackBoardControl: string | null,
+) {
+  const sortedPlayers = Array.from(draft.players.values()).sort(
+    (a, b) => a.score - b.score,
+  );
+  const lowestScore = sortedPlayers[0]?.score;
+  if (lowestScore === undefined) {
+    return fallbackBoardControl;
+  }
+
+  const tiedPlayers = sortedPlayers.filter((p) => p.score === lowestScore);
+  if (tiedPlayers.length === 1) {
+    return tiedPlayers[0].userId;
+  }
+
+  const tiedWithRecency = tiedPlayers
+    .map((p) => ({
+      userId: p.userId,
+      lastCorrect: getMostRecentCorrectOrder(draft.isAnswered, p.userId),
+    }))
+    .sort((a, b) => b.lastCorrect - a.lastCorrect);
+
+  if (tiedWithRecency[0].lastCorrect > 0) {
+    return tiedWithRecency[0].userId;
+  }
+  if (
+    fallbackBoardControl &&
+    tiedPlayers.some((p) => p.userId === fallbackBoardControl)
+  ) {
+    return fallbackBoardControl;
+  }
+  return tiedPlayers[0].userId;
+}
+
+function applyCheckCorrection(
+  draft: Draft<State>,
+  correction: Draft<CheckCorrection>,
+  nextChecks: Map<string, boolean>,
+  longForm: boolean,
+) {
+  const { round, i, j } = correction;
+  const clueAnswer = draft.isAnswered[round][i][j];
+  const previousCountedChecks = new Map(clueAnswer.answeredBy);
+  const nextCountedChecks = getCountedChecks(nextChecks, longForm);
+  const affectedUserIds = new Set([
+    ...previousCountedChecks.keys(),
+    ...nextCountedChecks.keys(),
+  ]);
+
+  for (const userId of affectedUserIds) {
+    const player = draft.players.get(userId) ?? draft.leftPlayers.get(userId);
+    if (!player) {
+      continue;
+    }
+    const clueValue = getClueValueForRound(draft, round, [i, j], userId);
+    const previousDelta = getCheckScoreDelta(
+      previousCountedChecks.get(userId),
+      clueValue,
+    );
+    const nextDelta = getCheckScoreDelta(
+      nextCountedChecks.get(userId),
+      clueValue,
+    );
+    player.score += nextDelta - previousDelta;
+  }
+
+  clueAnswer.answeredBy = nextCountedChecks;
+  correction.checks = nextChecks;
+
+  const correctedClueBoardControl = longForm
+    ? (getHighestScoringPlayerId(draft) ?? draft.boardControl)
+    : getCorrectBoardControl(nextCountedChecks, correction.boardControlBefore);
+
+  draft.boardControl =
+    correction.round === draft.round
+      ? correctedClueBoardControl
+      : getNextRoundBoardControl(draft, correctedClueBoardControl);
 }
 
 /** gameEngine is the reducer (aka state machine) which implements the game. */
@@ -271,6 +426,7 @@ export function gameEngine(state: State, action: Action): State {
           return;
         }
         transferBoardControl(draft, action.payload.userId);
+        transferCheckCorrectionBoardControl(draft, action.payload.userId);
         // Move to leftPlayers so they appear in post-game review.
         draft.players.delete(action.payload.userId);
         draft.leftPlayers.set(action.payload.userId, player);
@@ -345,6 +501,7 @@ export function gameEngine(state: State, action: Action): State {
           return;
         }
 
+        draft.checkCorrection = null;
         resumeClock(draft, action.ts);
 
         if (clue.wagerable) {
@@ -575,6 +732,7 @@ export function gameEngine(state: State, action: Action): State {
         }
 
         resumeClock(draft, action.ts);
+        recordCheckCorrection(draft, i, j, userId, correct);
 
         const clueValue = getClueValue(draft, [i, j], userId);
         const newScore = correct
@@ -605,10 +763,7 @@ export function gameEngine(state: State, action: Action): State {
 
           // Give board control to the player with the highest score after all
           // wagers add up.
-          const boardControl = Array.from(draft.players.entries()).sort(
-            ([, a], [, b]) => b.score - a.score,
-          )[0][0];
-          draft.boardControl = boardControl;
+          draft.boardControl = getHighestScoringPlayerId(draft) ?? null;
           draft.numAnswered += 1;
 
           const clueAnswer = draft.isAnswered[draft.round][i][j];
@@ -662,6 +817,49 @@ export function gameEngine(state: State, action: Action): State {
         draft.buzzes = buzzes;
         const clueAnswer = draft.isAnswered[draft.round][i][j];
         clueAnswer.answeredBy.set(userId, correct);
+      });
+    case ActionType.CorrectCheck:
+      if (!isCorrectCheckAction(action)) {
+        throw new Error(
+          "CorrectCheck action must have a round, index, user, and result",
+        );
+      }
+      return produce(state, (draft) => {
+        const { round, userId, i, j, correct } = action.payload;
+        const correction = draft.checkCorrection;
+        if (
+          draft.type !== GameState.ShowBoard ||
+          !correction ||
+          correction.round !== round ||
+          correction.i !== i ||
+          correction.j !== j ||
+          !draft.players.has(userId)
+        ) {
+          return;
+        }
+
+        const clue = draft.game.boards.at(round)?.categories.at(j)?.clues.at(i);
+        if (!clue) {
+          return;
+        }
+
+        const countedChecks = getCountedChecks(
+          correction.checks,
+          Boolean(clue.longForm),
+        );
+        const currentCorrect = countedChecks.get(userId);
+        if (currentCorrect === undefined || currentCorrect === correct) {
+          return;
+        }
+
+        const nextChecks = new Map(correction.checks);
+        nextChecks.set(userId, correct);
+        applyCheckCorrection(
+          draft,
+          correction,
+          nextChecks,
+          Boolean(clue.longForm),
+        );
       });
     case ActionType.NextClue:
       if (!isClueAction(action)) {
@@ -727,6 +925,7 @@ export function gameEngine(state: State, action: Action): State {
             draft.activeClue = null;
             draft.boardControl = null;
             draft.buzzes = new Map();
+            draft.checkCorrection = null;
             draft.numExpectedWagers = 0;
             return;
           }
@@ -734,40 +933,10 @@ export function gameEngine(state: State, action: Action): State {
           // Board control goes to the player with the lowest score. In the
           // case of a tie, the player who most recently answered correctly
           // gets control. Falls back to keeping the current controller.
-          const sortedPlayers = Array.from(draft.players.values()).sort(
-            (a, b) => a.score - b.score,
+          const newBoardControl = getNextRoundBoardControl(
+            draft,
+            draft.boardControl,
           );
-          const lowestScore = sortedPlayers[0].score;
-          const tiedPlayers = sortedPlayers.filter(
-            (p) => p.score === lowestScore,
-          );
-
-          let newBoardControl: string;
-          if (tiedPlayers.length === 1) {
-            newBoardControl = tiedPlayers[0].userId;
-          } else {
-            // Among tied players, find who answered correctly most recently.
-            const tiedWithRecency = tiedPlayers
-              .map((p) => ({
-                userId: p.userId,
-                lastCorrect: getMostRecentCorrectOrder(
-                  draft.isAnswered,
-                  p.userId,
-                ),
-              }))
-              .sort((a, b) => b.lastCorrect - a.lastCorrect);
-
-            if (tiedWithRecency[0].lastCorrect > 0) {
-              newBoardControl = tiedWithRecency[0].userId;
-            } else if (
-              draft.boardControl &&
-              tiedPlayers.some((p) => p.userId === draft.boardControl)
-            ) {
-              newBoardControl = draft.boardControl;
-            } else {
-              newBoardControl = tiedPlayers[0].userId;
-            }
-          }
 
           draft.type = GameState.PreviewRound;
           draft.activeClue = null;
@@ -820,6 +989,7 @@ export function gameEngine(state: State, action: Action): State {
         // player so it doesn't block the game.
         if (draft.players.has(newUserId)) {
           transferBoardControl(draft, oldUserId);
+          transferCheckCorrectionBoardControl(draft, oldUserId);
           draft.players.delete(oldUserId);
           draft.leftPlayers.set(oldUserId, oldPlayer);
           return;
@@ -872,6 +1042,23 @@ export function gameEngine(state: State, action: Action): State {
                 clueAnswer.answeredBy.set(newUserId, value);
               }
             }
+          }
+        }
+
+        // Transfer pending check-correction metadata.
+        if (draft.checkCorrection) {
+          if (draft.checkCorrection.boardControlBefore === oldUserId) {
+            draft.checkCorrection.boardControlBefore = newUserId;
+          }
+          if (draft.checkCorrection.checks.has(oldUserId)) {
+            draft.checkCorrection.checks = new Map(
+              Array.from(draft.checkCorrection.checks.entries()).map(
+                ([checkUserId, value]) => [
+                  checkUserId === oldUserId ? newUserId : checkUserId,
+                  value,
+                ],
+              ),
+            );
           }
         }
       });

--- a/app/engine/state.ts
+++ b/app/engine/state.ts
@@ -29,6 +29,22 @@ export interface ClueAnswer {
   answerOrder: number;
 }
 
+export interface CheckCorrection {
+  round: number;
+  i: number;
+  j: number;
+  boardControlBefore: string | null;
+  checks: Map<string, boolean>;
+}
+
+export interface PlayerCheckCorrection {
+  round: number;
+  i: number;
+  j: number;
+  correct: boolean;
+  value: number;
+}
+
 export interface Player {
   userId: string;
   name: string;
@@ -59,6 +75,7 @@ export interface State {
   readonly leftPlayers: Map<string, Player>;
   readonly wagers: Map<RoundIJKey, Map<string, number>>;
   readonly isAnswered: ClueAnswer[][][];
+  readonly checkCorrection: CheckCorrection | null;
 
   // per round state
   readonly activeClue: [number, number] | null;
@@ -87,6 +104,7 @@ export function stateFromGame(game: Game) {
     game,
     round: 0,
     isAnswered: [],
+    checkCorrection: null,
     numAnswered: 0,
     numCluesInBoard: getNumCluesInBoard(game, 0),
     numExpectedWagers: 0,
@@ -117,25 +135,82 @@ export function getPlayer(state: State, userId: string): Player | undefined {
   return state.players.get(userId) ?? state.leftPlayers.get(userId);
 }
 
+export function getCountedChecks(
+  checks: Map<string, boolean>,
+  longForm: boolean,
+) {
+  if (longForm) {
+    return new Map(checks);
+  }
+
+  const counted = new Map<string, boolean>();
+  for (const [userId, correct] of checks) {
+    counted.set(userId, correct);
+    if (correct) {
+      break;
+    }
+  }
+  return counted;
+}
+
+export function getCheckCorrectionForPlayer(
+  state: State,
+  userId: string,
+): PlayerCheckCorrection | undefined {
+  const correction = state.checkCorrection;
+  if (state.type !== GameState.ShowBoard || !correction) {
+    return undefined;
+  }
+  const { round, i, j, checks } = correction;
+
+  const clue = state.game.boards.at(round)?.categories.at(j)?.clues.at(i);
+  if (!clue) {
+    return undefined;
+  }
+
+  const countedChecks = getCountedChecks(checks, Boolean(clue.longForm));
+  const correct = countedChecks.get(userId);
+  if (correct === undefined) {
+    return undefined;
+  }
+
+  return {
+    round,
+    i,
+    j,
+    correct,
+    value: getClueValueForRound(state, round, [i, j], userId),
+  };
+}
+
+export function getClueValueForRound(
+  state: State,
+  round: number,
+  [i, j]: [number, number],
+  userId: string,
+) {
+  const board = state.game.boards.at(round);
+  const clue = board?.categories.at(j)?.clues.at(i);
+  if (!clue) {
+    throw new Error(`No clue exists at (${i}, ${j}) in round ${round}`);
+  }
+  if (clue.wagerable) {
+    const key = `${round},${i},${j}`;
+    const wagers = state.wagers.get(key);
+    return wagers?.get(userId) ?? 0;
+  }
+  return clue.value;
+}
+
 /** getClueValue gets the clue's wagered value if it's wagerable and its value
- * on the board otherwise.
+ * on the current board otherwise.
  */
 export function getClueValue(
   state: State,
   [i, j]: [number, number],
   userId: string,
 ) {
-  const board = state.game.boards.at(state.round);
-  const clue = board?.categories.at(j)?.clues.at(i);
-  if (!clue) {
-    throw new Error(`No clue exists at (${i}, ${j})`);
-  }
-  if (clue.wagerable) {
-    const key = `${state.round},${i},${j}`;
-    const wagers = state.wagers.get(key);
-    return wagers?.get(userId) ?? 0;
-  }
-  return clue.value;
+  return getClueValueForRound(state, state.round, [i, j], userId);
 }
 
 /** getNumCluesInBoard gets the number of clues in that round of the game.

--- a/app/engine/use-engine-context.ts
+++ b/app/engine/use-engine-context.ts
@@ -17,6 +17,7 @@ export const GameEngineContext = React.createContext<
   category: undefined,
   clue: undefined,
   connectionState: ConnectionState.DISCONNECTED,
+  getCheckCorrection: () => undefined,
   getClueValue: () => 0,
   soloDispatch: () => null,
   isAnswered: () => false,

--- a/app/engine/use-game-engine.ts
+++ b/app/engine/use-game-engine.ts
@@ -12,7 +12,12 @@ import {
   isTypedRoomEvent,
   roomEventToAction,
 } from "./room-event";
-import { type State, getClueValue, stateFromGame } from "./state";
+import {
+  type State,
+  getCheckCorrectionForPlayer,
+  getClueValue,
+  stateFromGame,
+} from "./state";
 
 export enum ConnectionState {
   /** Initial connection attempt (first load). */
@@ -93,6 +98,8 @@ export function stateToGameEngine(
     category,
     clue,
     connectionState,
+    getCheckCorrection: (userId: string) =>
+      getCheckCorrectionForPlayer(state, userId),
     getClueValue: getClueValueFn,
     soloDispatch: dispatch,
     isAnswered,

--- a/app/routes/room.$roomId.correct-check.tsx
+++ b/app/routes/room.$roomId.correct-check.tsx
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+import { ActionType } from "~/engine";
+import { getValidAuthSession } from "~/models/auth";
+import { createRoomEvent } from "~/models/room-event.server";
+import { getRoom } from "~/models/room.server";
+import { requireSessionUserId } from "~/session.server";
+import { parseFormData } from "~/utils/http.server";
+
+import type { Route } from "./+types/room.$roomId.correct-check";
+
+const formSchema = z.object({
+  round: z.coerce.number().int(),
+  i: z.coerce.number().int(),
+  j: z.coerce.number().int(),
+  userId: z.string(),
+  result: z.string(),
+});
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const formData = await request.formData();
+  const { round, i, j, userId, result } = parseFormData(formData, formSchema);
+
+  const correct = result === "correct";
+
+  const roomId = params.roomId ? parseInt(params.roomId) : undefined;
+  if (!roomId) {
+    throw new Response("room name not found in URL params", { status: 404 });
+  }
+
+  if (roomId === -1) {
+    return {
+      type: ActionType.CorrectCheck,
+      payload: { round, i, j, userId, correct },
+      ts: Date.now(),
+    };
+  }
+
+  const authSession = await getValidAuthSession(request);
+  await requireSessionUserId(request, userId, authSession);
+  const room = await getRoom(roomId, authSession?.accessToken);
+  if (!room) {
+    throw new Response("room not found", { status: 404 });
+  }
+
+  await createRoomEvent(
+    room.id,
+    ActionType.CorrectCheck,
+    {
+      round,
+      i,
+      j,
+      userId,
+      correct,
+    },
+    authSession?.accessToken,
+  );
+
+  return null;
+}

--- a/app/utils/offline-storage.test.ts
+++ b/app/utils/offline-storage.test.ts
@@ -96,6 +96,35 @@ describe("serializeState / deserializeState", () => {
     expect(result.clockAccumulatedMs).toBe(5000);
   });
 
+  it("preserves check-correction metadata", () => {
+    const state = stateFromGame(MOCK_GAME);
+    Object.assign(state, {
+      checkCorrection: {
+        round: 0,
+        i: 0,
+        j: 0,
+        boardControlBefore: "user1",
+        checks: new Map([
+          ["user1", false],
+          ["user2", true],
+        ]),
+      },
+    });
+
+    const result = deserializeState(serializeState(state), MOCK_GAME);
+
+    expect(result.checkCorrection).toEqual({
+      round: 0,
+      i: 0,
+      j: 0,
+      boardControlBefore: "user1",
+      checks: new Map([
+        ["user1", false],
+        ["user2", true],
+      ]),
+    });
+  });
+
   it("preserves activeClue tuple", () => {
     const state = stateFromGame(MOCK_GAME);
     Object.assign(state, { activeClue: [1, 0] });

--- a/app/utils/offline-storage.ts
+++ b/app/utils/offline-storage.ts
@@ -134,6 +134,7 @@ interface SerializedState {
   leftPlayers: [string, Player][];
   wagers: [string, [string, number][]][];
   isAnswered: SerializedClueAnswer[][][];
+  checkCorrection?: SerializedCheckCorrection | null;
   activeClue: [number, number] | null;
   numAnswered: number;
   numCluesInBoard: number;
@@ -149,6 +150,14 @@ interface SerializedClueAnswer {
   isAnswered: boolean;
   answeredBy: [string, boolean][];
   answerOrder: number;
+}
+
+interface SerializedCheckCorrection {
+  round: number;
+  i: number;
+  j: number;
+  boardControlBefore: string | null;
+  checks: [string, boolean][];
 }
 
 export function serializeState(state: State): SerializedState {
@@ -174,6 +183,12 @@ export function serializeState(state: State): SerializedState {
         })),
       ),
     ),
+    checkCorrection: state.checkCorrection
+      ? {
+          ...state.checkCorrection,
+          checks: Array.from(state.checkCorrection.checks.entries()),
+        }
+      : null,
     activeClue: state.activeClue,
     numAnswered: state.numAnswered,
     numCluesInBoard: state.numCluesInBoard,
@@ -209,6 +224,12 @@ export function deserializeState(
         ),
       ),
     ),
+    checkCorrection: serialized.checkCorrection
+      ? {
+          ...serialized.checkCorrection,
+          checks: new Map(serialized.checkCorrection.checks),
+        }
+      : null,
     activeClue: serialized.activeClue,
     numAnswered: serialized.numAnswered,
     numCluesInBoard: serialized.numCluesInBoard,


### PR DESCRIPTION
Adds a board-level correction button for a player's most recent counted check after a clue is dismissed. The correction flips that player's result, applies the double-value score swing including wagers, and recomputes board control and answeredBy as if the corrected result had been recorded originally.

Implementation: Tracks the ordered checks for the latest clue, keeping the change scoped to the active correction window. Later answers are ignored when an earlier check is corrected to correct, and restored if that correction is undone.

Adds online and solo action handling, preserves solo restore metadata, and covers normal, later-answer, leave, wager, and new-round correction cases.

Closes #40.