### PR TITLE
De-flake the e2e suite

### DIFF
--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -6,13 +6,17 @@ type ButtonProps = React.ComponentProps<"button">;
 
 type Props = {
   type?: "primary" | "default" | "transparent" | "danger";
+  /** The native button type. Defaults to "button" — a bare <button> inside a
+   * <form> would otherwise default to "submit", so onClick-only buttons
+   * (e.g. wager suggestions) would silently submit the surrounding form.
+   * Pass htmlType="submit" for actual submit buttons. */
   htmlType?: ButtonProps["type"];
   loading?: boolean;
 } & Omit<ButtonProps, "type">;
 
 export default function Button({
   type = "default",
-  htmlType,
+  htmlType = "button",
   loading,
   className,
   children,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,7 +17,7 @@ import Header from "~/components/header";
 import { getValidAuthSession } from "~/models/auth";
 import { getUserByEmail } from "~/models/user";
 import { parseUserSettings } from "~/models/user-settings.server";
-import { BASE_URL, getBrowserEnv, NODE_ENV } from "~/utils";
+import { BASE_URL, getBrowserEnv, IS_VERCEL, NODE_ENV } from "~/utils";
 import { UserSettingsProvider } from "~/utils/user-settings";
 
 import type { Route } from "./+types/root";
@@ -81,7 +81,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       ? await getUserByEmail(authSession.email, authSession.accessToken)
       : undefined;
     const userSettings = user ? parseUserSettings(user.settings) : undefined;
-    return { user, userSettings, env, BASE_URL, NODE_ENV };
+    return { user, userSettings, env, BASE_URL, NODE_ENV, IS_VERCEL };
   } catch {
     return {
       user: undefined,
@@ -89,6 +89,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       env,
       BASE_URL,
       NODE_ENV,
+      IS_VERCEL,
     };
   }
 }
@@ -103,7 +104,9 @@ export default function App({ loaderData }: Route.ComponentProps) {
         <Links />
       </head>
       <body className="relative flex min-h-screen flex-col">
-        {loaderData.NODE_ENV === "production" ? <Analytics /> : null}
+        {loaderData.NODE_ENV === "production" && loaderData.IS_VERCEL ? (
+          <Analytics />
+        ) : null}
         <ToastPrimitive.Provider swipeDirection="right">
           <ToastPrimitive.Viewport
             className={`fixed right-0 bottom-0 z-50 m-0 flex w-96 max-w-full list-none flex-col gap-3 p-[var(--viewport-padding)] outline-none [--viewport-padding:_25px]`}

--- a/app/routes/profile/game-info.tsx
+++ b/app/routes/profile/game-info.tsx
@@ -82,7 +82,9 @@ function DeleteGameModal({
           <Button autoFocus onClick={onClickClose} htmlType="button">
             Cancel
           </Button>
-          <Button type="danger">Delete game</Button>
+          <Button type="danger" htmlType="submit">
+            Delete game
+          </Button>
         </Dialog.Footer>
       </fetcher.Form>
     </Dialog>

--- a/app/utils/env.ts
+++ b/app/utils/env.ts
@@ -55,6 +55,16 @@ export const NODE_ENV = getEnv("NODE_ENV", {
   isSecret: false,
   isRequired: false,
 });
+/** Set by the Vercel platform at build and runtime. Used to skip
+ * Vercel-only integrations (e.g. analytics) in local production builds,
+ * where the injected /_vercel/* endpoints don't exist.
+ */
+export const IS_VERCEL = Boolean(
+  getEnv("VERCEL", {
+    isSecret: false,
+    isRequired: false,
+  }),
+);
 export const SUPABASE_URL = getEnv("SUPABASE_URL", { isSecret: false });
 export const SUPABASE_ANON_KEY = getEnv("SUPABASE_ANON_KEY", {
   isSecret: false,

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -77,6 +77,14 @@ export async function uploadGame(
 }
 
 /** Play through a single $200 clue and return to the board. */
+/** Wait for the realtime connection indicator before interacting with a
+ * real (non-mock) room. Events posted before the websocket subscription is
+ * established are only recovered by the missed-event catch-up, so tests
+ * should wait like a player watching the "Connecting..." banner would. */
+export async function waitForConnected(page: Page) {
+  await expect(page.getByText(/^Connected/)).toBeVisible({ timeout: 15_000 });
+}
+
 export async function playOneClue(page: Page) {
   const clueButton = page.getByRole("button", { name: "$ 200" }).first();
 

--- a/e2e/solves.spec.ts
+++ b/e2e/solves.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures";
-import { playOneClue, uploadGame } from "./helpers";
+import { playOneClue, uploadGame, waitForConnected } from "./helpers";
 
 test.describe("solves tracking", () => {
   test("playing a game records a solve on profile", async ({
@@ -12,10 +12,12 @@ test.describe("solves tracking", () => {
     // Navigate to the play route, which creates a real room and redirects
     await page.goto(`/game/${gameId}/play`);
 
-    // Wait for the room page to load, then join
+    // Wait for the room page to load and the realtime subscription to be
+    // established, then join.
     await expect(page.getByRole("button", { name: /join game/i })).toBeVisible({
       timeout: 10_000,
     });
+    await waitForConnected(page);
     await page.getByRole("button", { name: /join game/i }).click();
 
     // Start round 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "happy-dom": "^20.9.0",
         "npm-run-all2": "^8.0.4",
         "oxfmt": "^0.33.0",
-        "supabase": "^2.106.0",
+        "supabase": "^2.111.0",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.55.0",
@@ -534,6 +534,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/@ecies/ciphers": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
+      "integrity": "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2.7.10",
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@noble/ciphers": "^1.0.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -969,6 +984,48 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -2624,9 +2681,9 @@
       }
     },
     "node_modules/@supabase/cli-darwin-arm64": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.106.0.tgz",
-      "integrity": "sha512-xi/IAjjbebh6xA9Nkkb7ZwC5ACKJ38OqMoYk1y20ScW5Wt+pxTCcOcaWDWu+2u2Pwc3vTYnXhbknVcQt9UcChQ==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.111.0.tgz",
+      "integrity": "sha512-H1ucZ+9Z37Ha7uqYrKHfAy1vXWMVsN4gNlKaOpjKUYoHwDEbueEHVIDA1/PBIUd4HX+usJfpq+R+gWqzM/FKqQ==",
       "cpu": [
         "arm64"
       ],
@@ -2638,9 +2695,9 @@
       ]
     },
     "node_modules/@supabase/cli-darwin-x64": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-x64/-/cli-darwin-x64-2.106.0.tgz",
-      "integrity": "sha512-AT2s/8/3Ffb7IkcUXK6sA/iPCzJhh4Fh/XqzAGNGsVd1xCA/ZGniqU8BL03TqPkN1sR0iDaShjMLLIlHEflyPQ==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-x64/-/cli-darwin-x64-2.111.0.tgz",
+      "integrity": "sha512-4iMYm/XaAZJ8YzdJ2HBRVc7i9SRIwE6VQrnSt968WTt83M1y6knC7UENCKjMtO+As4QeZkICpUk50CeathqxbA==",
       "cpu": [
         "x64"
       ],
@@ -2652,13 +2709,16 @@
       ]
     },
     "node_modules/@supabase/cli-linux-arm64": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64/-/cli-linux-arm64-2.106.0.tgz",
-      "integrity": "sha512-L/pX7fkV31x7zPrUOcD6KMtZ03j16o41XxgkACFoOAE9lFz8KaJOBSHvn2QLeWEa2kLz7jwpisvpshPSMjuxOw==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64/-/cli-linux-arm64-2.111.0.tgz",
+      "integrity": "sha512-2KSHITFMXe2u5yALupBWHGeQ1IY4C8GkcIWPWgNFdtAPo03pgs1hLWgL1eeqSh/a0wB/6rgUlM1fQR/hAgCyCA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2666,13 +2726,16 @@
       ]
     },
     "node_modules/@supabase/cli-linux-arm64-musl": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.106.0.tgz",
-      "integrity": "sha512-2LExuOHuU6odXorNTvq4M/OvueW+wOs3KDsaCpk+scQMnB6LbmqNidEjXAsKpZu3zyE8MmmtdbJBlRNN/KLdcw==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.111.0.tgz",
+      "integrity": "sha512-RnvbVlJ4TX/UIwLiglBVQ2eL4GAl9SfWZmM5LENXyIaohBcRZHDva5t2OyK+BPGBtngjVGpb3QyfLdvkt9yJcw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2680,13 +2743,16 @@
       ]
     },
     "node_modules/@supabase/cli-linux-x64": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64/-/cli-linux-x64-2.106.0.tgz",
-      "integrity": "sha512-+ihtqFNURc8ssULgQoHQBR4AtUmxez9dtqjclqOV0y5r65SX7Ginmiby4XDW9LPlqHT+MB7OyD1vk0T6pQUtPA==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64/-/cli-linux-x64-2.111.0.tgz",
+      "integrity": "sha512-NwwNhiZZT4WYEPDXAbgZL+l77z/hoJ+w5t+52WBN1VlmoxwDmf2NP+UERM8wuCGFe/tmBlUuFE1eJYZfab0/qA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2694,13 +2760,16 @@
       ]
     },
     "node_modules/@supabase/cli-linux-x64-musl": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64-musl/-/cli-linux-x64-musl-2.106.0.tgz",
-      "integrity": "sha512-wz7heB3wwzmRdLRgqngd2VjPPNIdv6/Y8Q0dX/ZvjcL9/Nk8BYSZ7yjypapLpra+swRnbEJ4jAU6eAShiaB1Hg==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64-musl/-/cli-linux-x64-musl-2.111.0.tgz",
+      "integrity": "sha512-2QVpsy/3v+TzqE5GgTCPruoxTlF3d8QPGirjcnah8hP66nxXStB9yTvxmJq+LtO3gwMt1Kpm7is0roZVkV55Pw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2708,9 +2777,9 @@
       ]
     },
     "node_modules/@supabase/cli-windows-arm64": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-arm64/-/cli-windows-arm64-2.106.0.tgz",
-      "integrity": "sha512-QkEfRDiuuQwcfASo2DIJZ59AFV6xpqhPNo4r0kSVt38StYk3iL7ZcSOkZvGQWLlJ8kXKPBWEMhLnfHQF9r+Xfg==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-arm64/-/cli-windows-arm64-2.111.0.tgz",
+      "integrity": "sha512-twawKY5xfU2dNOnZrKDmrudxRG/XIKcBxOb6X2lMGJU3N1Hd+8oWpI9TwM5Qv+eXehtlsKDmUvbitStXvJr/xQ==",
       "cpu": [
         "arm64"
       ],
@@ -2722,9 +2791,9 @@
       ]
     },
     "node_modules/@supabase/cli-windows-x64": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-x64/-/cli-windows-x64-2.106.0.tgz",
-      "integrity": "sha512-1tQFbrH1KJhWJqHrY087XPz1WRi20eKG1pebG+6PjSD6XN+j0+x1PTOtBZrylXgY1fOg8BqgU8kl3KX8hI5l9w==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-x64/-/cli-windows-x64-2.111.0.tgz",
+      "integrity": "sha512-1F+X5tAYxAGx93ZZoIQBnIQ2Q2NnplKqjpigAS/zpTsNaWAjNi7EnxmuQKaEoAdqOHKbLhegVVDiw1+us3ZVpA==",
       "cpu": [
         "x64"
       ],
@@ -4608,6 +4677,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eciesjs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.5.0.tgz",
+      "integrity": "sha512-s0J9SEVYAEPg7J63GFMApLYzPH9VNIQIyC6s15JpnqVc0TqcKWdbgFlnAweEBRyMmko2dcs2sfC83Hj4J43tuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ecies/ciphers": "^0.2.6",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0"
+      },
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2.7.10",
+        "node": ">=16"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5622,6 +5709,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.6.tgz",
+      "integrity": "sha512-HwMtbJjMw8rC8dUTwCNilHJD+fxTeKM3JV1eprSmTjS41qwXSSt6exJXgyPK1QOu0jB9eDYLESRDkB3qaT3jnw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -7406,23 +7503,27 @@
       }
     },
     "node_modules/supabase": {
-      "version": "2.106.0",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.106.0.tgz",
-      "integrity": "sha512-jV0PJi5LqXUMZ4kriRLvST3DX1YDhrxOgnFJLOn6oUw3KQEFJPXhA60yLQ9aWG1E1uZCp4vUJwSuSGq3HPfaSQ==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.111.0.tgz",
+      "integrity": "sha512-0cjCRdYNV1h2XXa0wm04mdct7QuDU7sMul/NwETRJmN3+HCsdEu6u5n0oygL97fdf6sDrGmnAdBh8E4wsv1ayg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "eciesjs": "^0.5.0",
+        "jose": "^6.2.3"
+      },
       "bin": {
         "supabase": "dist/supabase.js"
       },
       "optionalDependencies": {
-        "@supabase/cli-darwin-arm64": "2.106.0",
-        "@supabase/cli-darwin-x64": "2.106.0",
-        "@supabase/cli-linux-arm64": "2.106.0",
-        "@supabase/cli-linux-arm64-musl": "2.106.0",
-        "@supabase/cli-linux-x64": "2.106.0",
-        "@supabase/cli-linux-x64-musl": "2.106.0",
-        "@supabase/cli-windows-arm64": "2.106.0",
-        "@supabase/cli-windows-x64": "2.106.0"
+        "@supabase/cli-darwin-arm64": "2.111.0",
+        "@supabase/cli-darwin-x64": "2.111.0",
+        "@supabase/cli-linux-arm64": "2.111.0",
+        "@supabase/cli-linux-arm64-musl": "2.111.0",
+        "@supabase/cli-linux-x64": "2.111.0",
+        "@supabase/cli-linux-x64-musl": "2.111.0",
+        "@supabase/cli-windows-arm64": "2.111.0",
+        "@supabase/cli-windows-x64": "2.111.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "happy-dom": "^20.9.0",
     "npm-run-all2": "^8.0.4",
     "oxfmt": "^0.33.0",
-    "supabase": "^2.106.0",
+    "supabase": "^2.111.0",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.55.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,27 @@ export default defineConfig({
     trace: "on-first-retry",
   },
 
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  // Specs that hit the shared database (auth, uploads, real rooms) are
+  // split into their own project that runs after the solo-game specs and
+  // without intra-file parallelism, so they don't race each other or the
+  // mock-game specs for the shared server and Supabase instance.
+  projects: [
+    {
+      name: "solo",
+      use: { ...devices["Desktop Chrome"] },
+      testIgnore: /(auth|solves|game-management|settings)\.spec\.ts/,
+    },
+    {
+      name: "db",
+      use: { ...devices["Desktop Chrome"] },
+      testMatch: /(auth|solves|game-management|settings)\.spec\.ts/,
+      dependencies: ["solo"],
+      // These specs share one test user and one database, so they cannot
+      // run concurrently with each other.
+      workers: 1,
+      fullyParallel: false,
+    },
+  ],
 
   webServer: {
     command: webServerCommand,


### PR DESCRIPTION
Four fixes for the flakiest parts of CI and local e2e runs, plus a log-noise fix. No behavior changes for players except one real bug fix (All-in, below).

## What was flaking

Looking at the last ~60 runs of the Test workflow and reproducing locally:

- **CI:** the most common failure was `toomanyrequests: Rate exceeded` while `supabase start` pulls images (it pulls even excluded services like `storage-api`). This hit both check runs on #128, plus pushes to `main`.
- **Locally:** `all-in button sets max wager` and `solves › playing a game records a solve on profile` failed under the fully-parallel suite but passed in isolation.

## Fixes

- **Upgrade supabase CLI to `^2.111.0`.** supabase/cli#5660 (shipped in v2.108.0) added registry fallbacks — pulls now try ECR → GHCR → Docker Hub instead of failing on a single registry's rate limit. CI installs with `useLockFile: false` so it has been floating on fixed versions since mid-June; this makes the fix explicit for local runs too.

- **Default `Button`'s `htmlType` to `"button"`.** A bare `<button>` inside a `<form>` defaults to `type="submit"`, so onClick-only Buttons like **All-in** and the wager suggestion chips silently submitted the wager form in the same click that set the input — a React-flush-vs-form-serialization race that flaked the test and could commit a player's wager without them pressing Submit. The only Button relying on the implicit submit (Delete game) now passes `htmlType="submit"` explicitly.

- **Split Playwright specs into two projects.** The database-backed specs (`auth`, `solves`, `game-management`, `settings`) all share one test user and one Supabase instance, so they can't run concurrently with each other — `fullyParallel: false` alone isn't enough because it only serializes within a file. The new `db` project runs with `workers: 1` after the parallel `solo` (mock-game) project. Note: running a db spec directly pulls in the solo phase unless you pass `--no-deps`.

- **Wait for the realtime connection indicator before joining a real room** in the solves spec (`waitForConnected` helper). Events posted before the websocket subscription is live are only recovered by the missed-event catch-up; the test now waits like a player watching the "Connecting…" banner would.

- **Gate Vercel Analytics on the `VERCEL` env var** in addition to production, so local production builds (like the e2e web server) stop spamming `No route matches "/_vercel/insights/script.js"` over real failures in test logs.

## Validation

- Unit tests (5,360), typecheck, lint, format: green.
- Full Playwright suite against local Supabase (CLI 2.111.0): **28/28 passed** in one run — including the two previously flaky specs, which also pass repeatedly under the new serial db project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ce06dbfd-1642-4ee0-9d55-423e7fb21aa0)
