### PR TITLE
Add search crawler metadata and sitemap

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -12,7 +12,8 @@ import { renderToPipeableStream } from "react-dom/server";
 import type { EntryContext } from "react-router";
 import { ServerRouter } from "react-router";
 
-import { SUPABASE_URL } from "~/utils";
+import { BASE_URL, SUPABASE_URL } from "~/utils";
+import { getSearchMetadata, NO_INDEX_DIRECTIVES } from "~/utils/seo";
 
 export const streamTimeout = 5_000;
 
@@ -22,6 +23,16 @@ export default function handleRequest(
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
 ) {
+  const searchMetadata = getSearchMetadata(
+    new URL(request.url).pathname,
+    BASE_URL,
+  );
+  // Mirror the page's robots policy in the HTTP response so crawlers receive
+  // it even for streamed and error documents, independently of the HTML head.
+  responseHeaders.set(
+    "X-Robots-Tag",
+    responseStatusCode >= 400 ? NO_INDEX_DIRECTIVES : searchMetadata.robots,
+  );
   // Prevent browsers from MIME-sniffing a response away from the declared type
   responseHeaders.set("X-Content-Type-Options", "nosniff");
   // Prevent clickjacking by blocking iframe embedding

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,6 +8,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useLocation,
   useRouteError,
 } from "react-router";
 
@@ -18,37 +19,49 @@ import { getValidAuthSession } from "~/models/auth";
 import { getUserByEmail } from "~/models/user";
 import { parseUserSettings } from "~/models/user-settings.server";
 import { BASE_URL, getBrowserEnv, IS_VERCEL, NODE_ENV } from "~/utils";
+import { getSearchMetadata, NO_INDEX_DIRECTIVES } from "~/utils/seo";
 import { UserSettingsProvider } from "~/utils/user-settings";
 
 import type { Route } from "./+types/root";
 
 import stylesheet from "./styles.css?url";
 
-const META_URL = "https://whatis.club";
 const META_TITLE = "Jep!";
 const META_DESCRIPTION =
   "A website for sharing J! trivia and playing collaboratively with friends in real time.";
-const META_IMAGE = META_URL + "/images/meta.png";
 
-export const meta: Route.MetaFunction = () => [
-  { title: META_TITLE },
-  { name: "title", content: META_TITLE },
-  { name: "description", content: META_DESCRIPTION },
+export const meta: Route.MetaFunction = ({ loaderData }) => {
+  if (!loaderData) {
+    return [
+      { title: META_TITLE },
+      { name: "title", content: META_TITLE },
+      { name: "description", content: META_DESCRIPTION },
+    ];
+  }
 
-  // Open Graph / Facebook
-  { property: "og:type", content: "website" },
-  { property: "og:url", content: META_URL },
-  { property: "og:title", content: META_TITLE },
-  { property: "og:description", content: META_DESCRIPTION },
-  { property: "og:image", content: META_IMAGE },
+  const metaUrl = loaderData.BASE_URL;
+  const metaImage = new URL("/images/meta.png", metaUrl).toString();
 
-  // Twitter
-  { property: "twitter:card", content: "summary_large_image" },
-  { property: "twitter:url", content: META_URL },
-  { property: "twitter:title", content: META_TITLE },
-  { property: "twitter:description", content: META_DESCRIPTION },
-  { property: "twitter:image", content: META_IMAGE },
-];
+  return [
+    { title: META_TITLE },
+    { name: "title", content: META_TITLE },
+    { name: "description", content: META_DESCRIPTION },
+
+    // Open Graph / Facebook
+    { property: "og:type", content: "website" },
+    { property: "og:url", content: metaUrl },
+    { property: "og:title", content: META_TITLE },
+    { property: "og:description", content: META_DESCRIPTION },
+    { property: "og:image", content: metaImage },
+
+    // Twitter
+    { property: "twitter:card", content: "summary_large_image" },
+    { property: "twitter:url", content: metaUrl },
+    { property: "twitter:title", content: META_TITLE },
+    { property: "twitter:description", content: META_DESCRIPTION },
+    { property: "twitter:image", content: metaImage },
+  ];
+};
 
 export const links: Route.LinksFunction = () => [
   { rel: "icon", href: "/favicon.ico", type: "image/x-icon", sizes: "16x16" },
@@ -101,11 +114,21 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export default function App({ loaderData }: Route.ComponentProps) {
+  const location = useLocation();
+  const searchMetadata = getSearchMetadata(
+    location.pathname,
+    loaderData.BASE_URL,
+  );
+
   return (
     <html lang="en">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta name="robots" content={searchMetadata.robots} />
+        {searchMetadata.canonicalUrl ? (
+          <link rel="canonical" href={searchMetadata.canonicalUrl} />
+        ) : null}
         <Meta />
         <Links />
       </head>
@@ -155,6 +178,7 @@ function ErrorDocument({ children }: { children: React.ReactNode }) {
         <title>Oh no!</title>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta name="robots" content={NO_INDEX_DIRECTIVES} />
         <Meta />
         <Links />
       </head>

--- a/app/routes/[game.schema.json].tsx
+++ b/app/routes/[game.schema.json].tsx
@@ -89,6 +89,8 @@ export function loader() {
     status: 200,
     headers: {
       "Content-Type": "application/schema+json",
+      // This machine-readable schema is linked for tooling, not search results.
+      "X-Robots-Tag": "noindex",
     },
   });
 }

--- a/app/routes/[robots.txt].ts
+++ b/app/routes/[robots.txt].ts
@@ -1,0 +1,19 @@
+import { href } from "react-router";
+
+import { BASE_URL } from "~/utils";
+
+export function loader() {
+  // Crawlers need access to every route in order to see its noindex directive.
+  const sitemapUrl = new URL(href("/sitemap.xml"), BASE_URL).toString();
+  const body = `User-agent: *
+Allow: /
+Sitemap: ${sitemapUrl}
+`;
+
+  return new Response(body, {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/app/routes/[sitemap.xml].ts
+++ b/app/routes/[sitemap.xml].ts
@@ -1,0 +1,21 @@
+import { BASE_URL } from "~/utils";
+import { INDEXABLE_PATHS } from "~/utils/seo";
+
+export function loader() {
+  const urls = INDEXABLE_PATHS.map(
+    (pathname) =>
+      `  <url><loc>${new URL(pathname, BASE_URL).toString()}</loc></url>`,
+  ).join("\n");
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+
+  return new Response(body, {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "Content-Type": "application/xml; charset=utf-8",
+    },
+  });
+}

--- a/app/routes/game.$gameId.tsx
+++ b/app/routes/game.$gameId.tsx
@@ -78,6 +78,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     status: 200,
     headers: {
       "Content-Type": "application/json",
+      // Keep this raw game-data endpoint out of human-facing search results.
+      "X-Robots-Tag": "noindex",
     },
   });
 }

--- a/app/utils/seo.test.ts
+++ b/app/utils/seo.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { getSearchMetadata, INDEXABLE_PATHS } from "./seo";
+
+const BASE_URL = "https://whatis.club";
+
+describe("getSearchMetadata", () => {
+  it.each(INDEXABLE_PATHS)("indexes public page %s", (pathname) => {
+    expect(getSearchMetadata(pathname, BASE_URL)).toEqual({
+      canonicalUrl: new URL(pathname, BASE_URL).toString(),
+      robots: "index, follow",
+    });
+  });
+
+  it("normalizes a trailing slash in public canonical URLs", () => {
+    expect(getSearchMetadata("/howto/", BASE_URL)).toEqual({
+      canonicalUrl: `${BASE_URL}/howto`,
+      robots: "index, follow",
+    });
+  });
+
+  it.each([
+    "/room/33394-dimp",
+    "/room/33394-dimp/summary",
+    "/profile",
+    "/settings",
+    "/login",
+    "/game/example",
+    "/mock",
+  ])("keeps private and utility page %s out of search", (pathname) => {
+    expect(getSearchMetadata(pathname, BASE_URL)).toEqual({
+      canonicalUrl: undefined,
+      robots: "noindex, follow",
+    });
+  });
+});

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -1,0 +1,32 @@
+import { href } from "react-router";
+
+// href() checks these paths against React Router's generated route types, so a
+// renamed or removed public route fails typechecking instead of going stale.
+export const INDEXABLE_PATHS = [
+  href("/"),
+  href("/howto"),
+  href("/help"),
+  href("/community"),
+] as const;
+
+export const INDEX_DIRECTIVES = "index, follow";
+export const NO_INDEX_DIRECTIVES = "noindex, follow";
+
+function normalizePathname(pathname: string) {
+  if (pathname === "/") return pathname;
+  return pathname.replace(/\/+$/, "");
+}
+
+export function getSearchMetadata(pathname: string, baseUrl: string) {
+  const normalizedPathname = normalizePathname(pathname);
+  const indexable = INDEXABLE_PATHS.some(
+    (publicPath) => publicPath === normalizedPathname,
+  );
+
+  return {
+    canonicalUrl: indexable
+      ? new URL(normalizedPathname, baseUrl).toString()
+      : undefined,
+    robots: indexable ? INDEX_DIRECTIVES : NO_INDEX_DIRECTIVES,
+  };
+}


### PR DESCRIPTION
Adds route-aware robots metadata, canonical URLs, and matching X-Robots-Tag headers so only public informational pages are indexed.
Serves cacheable robots.txt and sitemap.xml resources using the configured base URL and type-checked React Router paths, while excluding raw JSON endpoints from search.
Adds focused tests for the indexing policy and updates social metadata to use the configured base URL.
Validation passed for formatting, typecheck, lint, 5,391 unit tests, and the production build; Playwright could not start because this cloud workspace has no local Supabase service.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/089d2bb8-23e5-4478-8f4f-c3677050a43e)
